### PR TITLE
build Sailfish app with static plugins as for IOS

### DIFF
--- a/rpm/harbour-noson.spec
+++ b/rpm/harbour-noson.spec
@@ -43,10 +43,9 @@ pushd build-%{_target_cpu}
 popd
 
 %files
-%{_bindir}/noson-app
-%{_datadir}/applications/io.github.janbar.noson.desktop
+%{_bindir}/noson
+%{_datadir}/applications/noson.desktop
 %{_datadir}/icons/hicolor/
 %{_datadir}/metainfo/io.github.janbar.noson.appdata.xml
-%{_libdir}/noson/
 
 %changelog


### PR DESCRIPTION
To get rid of warnings and double process on start I build the app in one
piece of cake. The generated binary is called 'noson'.

This change will work only with the latest sources of the app, because the
project configuration has been updated to manage the setting QT_STATICPLUGIN
for the Sailfish build.